### PR TITLE
WIP: Fix deprecation warnings and precompile

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
+julia 0.3
 Codecs
 Compat
 Dates

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -1,4 +1,4 @@
-
+VERSION >= v"0.4-" && __precompile__()
 
 module YAML
     import Base: start, next, done, isempty, length, show
@@ -67,11 +67,11 @@ module YAML
 
 
 
-    load(input::String) = load(IOBuffer(input))
-    load_all(input::String) = load_all(IOBuffer(input))
+    load(input::AbstractString) = load(IOBuffer(input))
+    load_all(input::AbstractString) = load_all(IOBuffer(input))
 
 
-    function load_file(filename::String)
+    function load_file(filename::AbstractString)
         input = open(filename)
         data = load(input)
         close(input)
@@ -79,7 +79,7 @@ module YAML
     end
 
 
-    function load_all_file(filename::String)
+    function load_all_file(filename::AbstractString)
         input = open(filename)
         data = load_all(input)
         close(input)

--- a/src/buffered_input.jl
+++ b/src/buffered_input.jl
@@ -7,8 +7,8 @@
 type BufferedInput
     input::IO
     buffer::Vector{Char}
-    offset::Uint
-    avail::Uint
+    offset::UInt64
+    avail::UInt64
 
     function BufferedInput(input::IO)
         return new(input, Array(Char, 0), 0, 0)

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -4,11 +4,11 @@ include("resolver.jl")
 
 
 immutable ComposerError
-    context::Union(String, Nothing)
-    context_mark::Union(Mark, Nothing)
-    problem::Union(String, Nothing)
-    problem_mark::Union(Mark, Nothing)
-    note::Union(String, Nothing)
+    context::Union{AbstractString, Void}
+    context_mark::Union{Mark, Void}
+    problem::Union{AbstractString, Void}
+    problem_mark::Union{Mark, Void}
+    note::Union{AbstractString, Void}
 
     function ComposerError(context=nothing, context_mark=nothing,
                            problem=nothing, problem_mark=nothing,
@@ -20,13 +20,13 @@ end
 
 type Composer
     input::EventStream
-    anchors::Dict{String, Node}
+    anchors::Dict{AbstractString, Node}
     resolver::Resolver
 end
 
 
 function compose(events)
-    composer = Composer(events, Dict{String, Node}(), Resolver())
+    composer = Composer(events, Dict{AbstractString, Node}(), Resolver())
     @assert typeof(forward!(composer.input)) == StreamStartEvent
     node = compose_document(composer)
     if typeof(peek(composer.input)) == StreamEndEvent
@@ -47,8 +47,8 @@ function compose_document(composer::Composer)
 end
 
 
-function compose_node(composer::Composer, parent::Union(Node, Nothing),
-                      index::Union(Int, Node, Nothing))
+function compose_node(composer::Composer, parent::Union{Node, Void},
+                      index::Union{Int, Node, Void})
     event = peek(composer.input)
     if typeof(event) == AliasEvent
         forward!(composer.input)
@@ -83,7 +83,7 @@ function compose_node(composer::Composer, parent::Union(Node, Nothing),
 end
 
 
-function compose_scalar_node(composer::Composer, anchor::Union(String, Nothing))
+function compose_scalar_node(composer::Composer, anchor::Union{AbstractString, Void})
     event = forward!(composer.input)
     tag = event.tag
     if tag === nothing || tag == "!"
@@ -101,7 +101,7 @@ function compose_scalar_node(composer::Composer, anchor::Union(String, Nothing))
 end
 
 
-function compose_sequence_node(composer::Composer, anchor::Union(String, Nothing))
+function compose_sequence_node(composer::Composer, anchor::Union{AbstractString, Void})
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"
@@ -128,7 +128,7 @@ function compose_sequence_node(composer::Composer, anchor::Union(String, Nothing
 end
 
 
-function compose_mapping_node(composer::Composer, anchor::Union(String, Nothing))
+function compose_mapping_node(composer::Composer, anchor::Union{AbstractString, Void})
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -173,7 +173,7 @@ end
 
 
 function construct_yaml_int(constructor::Constructor, node::Node)
-    value = AbstractString(construct_scalar(constructor, node))
+    value = string(construct_scalar(constructor, node))
     value = lowercase(replace(value, "_", ""))
 
     if in(':', value)
@@ -195,7 +195,7 @@ end
 
 
 function construct_yaml_float(constructor::Constructor, node::Node)
-    value = AbstractString(construct_scalar(constructor, node))
+    value = string(construct_scalar(constructor, node))
     value = lowercase(replace(value, "_", ""))
 
     if in(':', value)
@@ -272,7 +272,7 @@ function construct_yaml_timestamp(constructor::Constructor, node::Node)
         if length(ms) > 3
             ms = ms[1:3]
         end
-        ms = parse(Int, AbstractString(ms, repeat("0", 3 - length(ms))))
+        ms = parse(Int, string(ms, repeat("0", 3 - length(ms))))
     end
 
     delta_hr = 0
@@ -312,7 +312,7 @@ end
 
 
 function construct_yaml_str(constructor::Constructor, node::Node)
-    AbstractString(construct_scalar(constructor, node))
+    string(construct_scalar(constructor, node))
 end
 
 
@@ -340,7 +340,7 @@ end
 
 
 function construct_yaml_binary(constructor::Constructor, node::Node)
-    value = replace(AbstractString(construct_scalar(constructor, node)), "\n", "")
+    value = replace(string(construct_scalar(constructor, node)), "\n", "")
     Codecs.decode(Codecs.Base64, value)
 end
 

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -1,11 +1,11 @@
 
 
 immutable ConstructorError
-    context::Union(String, Nothing)
-    context_mark::Union(Mark, Nothing)
-    problem::Union(String, Nothing)
-    problem_mark::Union(Mark, Nothing)
-    note::Union(String, Nothing)
+    context::Union{AbstractString, Void}
+    context_mark::Union{Mark, Void}
+    problem::Union{AbstractString, Void}
+    problem_mark::Union{Mark, Void}
+    note::Union{AbstractString, Void}
 
     function ConstructorError(context=nothing, context_mark=nothing,
                               problem=nothing, problem_mark=nothing,
@@ -20,7 +20,7 @@ type Constructor
     constructed_objects::Dict{Node, Any}
     recursive_objects::Set{Node}
     deep_construct::Bool
-    yaml_constructors::Dict{Union(String, Nothing), Function}
+    yaml_constructors::Dict{Union{AbstractString, Void}, Function}
 
     function Constructor()
         new(Dict{Node, Any}(), Set{Node}(), false,
@@ -173,14 +173,14 @@ end
 
 
 function construct_yaml_int(constructor::Constructor, node::Node)
-    value = string(construct_scalar(constructor, node))
+    value = AbstractString(construct_scalar(constructor, node))
     value = lowercase(replace(value, "_", ""))
 
     if in(':', value)
         # TODO
         #throw(ConstructorError(nothing, nothing,
             #"sexagesimal integers not yet implemented", node.start_mark))
-        warn("sexagesimal integers not yet implemented. Returning string.")
+        warn("sexagesimal integers not yet implemented. Returning AbstractString.")
         return value
     end
 
@@ -195,14 +195,14 @@ end
 
 
 function construct_yaml_float(constructor::Constructor, node::Node)
-    value = string(construct_scalar(constructor, node))
+    value = AbstractString(construct_scalar(constructor, node))
     value = lowercase(replace(value, "_", ""))
 
     if in(':', value)
         # TODO
         # throw(ConstructorError(nothing, nothing,
         #     "sexagesimal floats not yet implemented", node.start_mark))
-        warn("sexagesimal floats not yet implemented. Returning string.")
+        warn("sexagesimal floats not yet implemented. Returning AbstractString.")
         return value
     end
 
@@ -272,7 +272,7 @@ function construct_yaml_timestamp(constructor::Constructor, node::Node)
         if length(ms) > 3
             ms = ms[1:3]
         end
-        ms = parse(Int, string(ms, repeat("0", 3 - length(ms))))
+        ms = parse(Int, AbstractString(ms, repeat("0", 3 - length(ms))))
     end
 
     delta_hr = 0
@@ -312,7 +312,7 @@ end
 
 
 function construct_yaml_str(constructor::Constructor, node::Node)
-    string(construct_scalar(constructor, node))
+    AbstractString(construct_scalar(constructor, node))
 end
 
 
@@ -340,12 +340,12 @@ end
 
 
 function construct_yaml_binary(constructor::Constructor, node::Node)
-    value = replace(string(construct_scalar(constructor, node)), "\n", "")
+    value = replace(AbstractString(construct_scalar(constructor, node)), "\n", "")
     Codecs.decode(Codecs.Base64, value)
 end
 
 
-const default_yaml_constructors = @compat Dict{Union(String, Nothing), Function}(
+const default_yaml_constructors = @compat Dict{Union{AbstractString, Void}, Function}(
         "tag:yaml.org,2002:null"      => construct_yaml_null,
         "tag:yaml.org,2002:bool"      => construct_yaml_bool,
         "tag:yaml.org,2002:int"       => construct_yaml_int,

--- a/src/events.jl
+++ b/src/events.jl
@@ -4,7 +4,7 @@ abstract Event
 immutable StreamStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    encoding::String
+    encoding::AbstractString
 end
 
 
@@ -18,8 +18,8 @@ immutable DocumentStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
     explicit::Bool
-    version::Union(String, Nothing)
-    tags::Union(Dict{String, String}, Nothing)
+    version::Union{AbstractString, Void}
+    tags::Union{Dict{AbstractString, AbstractString}, Void}
 
     function DocumentStartEvent(start_mark::Mark,end_mark::Mark,
                                 explicit::Bool, version=nothing,
@@ -39,26 +39,26 @@ end
 immutable AliasEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union(String, Nothing)
+    anchor::Union{AbstractString, Void}
 end
 
 
 immutable ScalarEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union(String, Nothing)
-    tag::Union(String, Nothing)
+    anchor::Union{AbstractString, Void}
+    tag::Union{AbstractString, Void}
     implicit::Tuple
-    value::String
-    style::Union(Char, Nothing)
+    value::AbstractString
+    style::Union{Char, Void}
 end
 
 
 immutable SequenceStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union(String, Nothing)
-    tag::Union(String, Nothing)
+    anchor::Union{AbstractString, Void}
+    tag::Union{AbstractString, Void}
     implicit::Bool
     flow_style::Bool
 end
@@ -73,8 +73,8 @@ end
 immutable MappingStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::Union(String, Nothing)
-    tag::Union(String, Nothing)
+    anchor::Union{AbstractString, Void}
+    tag::Union{AbstractString, Void}
     implicit::Bool
     flow_style::Bool
 end

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -2,28 +2,28 @@
 abstract Node
 
 type ScalarNode <: Node
-    tag::String
-    value::String
-    start_mark::Union(Mark, Nothing)
-    end_mark::Union(Mark, Nothing)
-    style::Union(Char, Nothing)
+    tag::AbstractString
+    value::AbstractString
+    start_mark::Union{Mark, Void}
+    end_mark::Union{Mark, Void}
+    style::Union{Char, Void}
 end
 
 
 type SequenceNode <: Node
-    tag::String
+    tag::AbstractString
     value::Vector
-    start_mark::Union(Mark, Nothing)
-    end_mark::Union(Mark, Nothing)
+    start_mark::Union{Mark, Void}
+    end_mark::Union{Mark, Void}
     flow_style::Bool
 end
 
 
 type MappingNode <: Node
-    tag::String
+    tag::AbstractString
     value::Vector
-    start_mark::Union(Mark, Nothing)
-    end_mark::Union(Mark, Nothing)
+    start_mark::Union{Mark, Void}
+    end_mark::Union{Mark, Void}
     flow_style::Bool
 end
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -265,7 +265,7 @@ function parse_node(stream::EventStream; block=false, indentless_sequence=false)
                                   "found undefined tag handle $(handle)",
                                   tag_mark))
             end
-            tag = AbstractString(stream.tag_handles[handle], suffix)
+            tag = string(stream.tag_handles[handle], suffix)
         else
             tag = suffix
         end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,15 +1,15 @@
 
 include("events.jl")
 
-const DEFAULT_TAGS = @compat Dict{String,String}("!" => "!", "!!" => "tag:yaml.org,2002:")
+const DEFAULT_TAGS = @compat Dict{AbstractString,AbstractString}("!" => "!", "!!" => "tag:yaml.org,2002:")
 
 
 immutable ParserError
-    context::Union(String, Nothing)
-    context_mark::Union(Mark, Nothing)
-    problem::Union(String, Nothing)
-    problem_mark::Union(Mark, Nothing)
-    note::Union(String, Nothing)
+    context::Union{AbstractString, Void}
+    context_mark::Union{Mark, Void}
+    problem::Union{AbstractString, Void}
+    problem_mark::Union{Mark, Void}
+    note::Union{AbstractString, Void}
 
     function ParserError(context=nothing, context_mark=nothing,
                          problem=nothing, problem_mark=nothing,
@@ -21,17 +21,17 @@ end
 
 type EventStream
     input::TokenStream
-    next_event::Union(Event, Nothing)
-    state::Union(Function, Nothing)
+    next_event::Union{Event, Void}
+    state::Union{Function, Void}
     states::Vector{Function}
     marks::Vector{Mark}
-    yaml_version::Union(Tuple, Nothing)
-    tag_handles::Dict{String, String}
-    end_of_stream::Union(StreamEndEvent, Nothing,)
+    yaml_version::Union{Tuple, Void}
+    tag_handles::Dict{AbstractString, AbstractString}
+    end_of_stream::Union{StreamEndEvent, Void,}
 
     function EventStream(input::TokenStream)
         new(input, nothing, parse_stream_start, Function[], Mark[],
-            nothing, Dict{String, String}(), nothing)
+            nothing, Dict{AbstractString, AbstractString}(), nothing)
     end
 end
 
@@ -75,7 +75,7 @@ end
 
 function process_directives(stream::EventStream)
     stream.yaml_version = nothing
-    stream.tag_handles = Dict{String, String}()
+    stream.tag_handles = Dict{AbstractString, AbstractString}()
     while typeof(peek(stream.input)) == DirectiveToken
         token = forward!(stream.input)
         if token.name == "YAML"
@@ -265,7 +265,7 @@ function parse_node(stream::EventStream; block=false, indentless_sequence=false)
                                   "found undefined tag handle $(handle)",
                                   tag_mark))
             end
-            tag = string(stream.tag_handles[handle], suffix)
+            tag = AbstractString(stream.tag_handles[handle], suffix)
         else
             tag = suffix
         end

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -9,14 +9,14 @@ end
 
 type QueueNode{T}
     value::T
-    next::Union(QueueNode, Nothing)
+    next::Union{QueueNode, Void}
 end
 
 
 type Queue{T}
-    front::Union(QueueNode{T}, Nothing)
-    back::Union(QueueNode{T}, Nothing)
-    length::Uint
+    front::Union{QueueNode{T}, Void}
+    back::Union{QueueNode{T}, Void}
+    length::UInt64
 
     function Queue()
         new(nothing, nothing, 0)

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -4,9 +4,9 @@ include("buffered_input.jl")
 
 # Position within the document being parsed
 immutable Mark
-    index::Uint
-    line::Uint
-    column::Uint
+    index::UInt64
+    line::UInt64
+    column::UInt64
 end
 
 
@@ -23,7 +23,7 @@ end
 
 
 immutable SimpleKey
-    token_number::Uint
+    token_number::UInt64
     required::Bool
     mark::Mark
 end
@@ -31,9 +31,9 @@ end
 
 # Errors thrown by the scanner.
 immutable ScannerError <: Exception
-    context::Union(String, Nothing)
-    context_mark::Union(Mark, Nothing)
-    problem::String
+    context::Union{AbstractString, Void}
+    context_mark::Union{Mark, Void}
+    problem::AbstractString
     problem_mark::Mark
 end
 
@@ -52,20 +52,20 @@ type TokenStream
     token_queue::Queue{Token}
 
     # Index of the start of the head of the stream. (0-based)
-    index::Uint
+    index::UInt64
 
     # Index of the current column. (0-based)
-    column::Uint
+    column::UInt64
 
     # Current line numebr. (0-based)
-    line::Uint
+    line::UInt64
 
     # Number of tokens read, not including those still in token_queue.
-    tokens_taken::Uint
+    tokens_taken::UInt64
 
     # The number of unclosed '{' and '['. `flow_level == 0` means block
     # context.
-    flow_level::Uint
+    flow_level::UInt64
 
     # Current indentation level.
     indent::Int
@@ -1420,7 +1420,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
 end
 
 
-function scan_tag_handle(stream::TokenStream, name::String, start_mark::Mark)
+function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::Mark)
     c = peek(stream.input)
     if c != '!'
         throw(ScannerError("while scanning a $(name)", start_mark,
@@ -1449,7 +1449,7 @@ function scan_tag_handle(stream::TokenStream, name::String, start_mark::Mark)
 end
 
 
-function scan_tag_uri(stream::TokenStream, name::String, start_mark::Mark)
+function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mark)
     chunks = Any[]
     length = 0
     c = peek(stream.input, length)
@@ -1481,7 +1481,7 @@ function scan_tag_uri(stream::TokenStream, name::String, start_mark::Mark)
 end
 
 
-function scan_uri_escapes(stream::TokenStream, name::String, start_mark::Mark)
+function scan_uri_escapes(stream::TokenStream, name::AbstractString, start_mark::Mark)
     bytes = Any[]
     mark = get_mark(stream)
     while peek(stream.input) == '%'

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -7,8 +7,8 @@ abstract Token
 # The '%YAML' directive.
 immutable DirectiveToken <: Token
     span::Span
-    name::String
-    value::Union(Tuple, Nothing)
+    name::AbstractString
+    value::Union{Tuple, Void}
 end
 
 # '---'
@@ -24,7 +24,7 @@ end
 # The stream start
 immutable StreamStartToken <: Token
     span::Span
-    encoding::String
+    encoding::AbstractString
 end
 
 # The stream end
@@ -90,13 +90,13 @@ end
 # '*anchor'
 immutable AliasToken <: Token
     span::Span
-    value::String
+    value::AbstractString
 end
 
 # '&anchor'
 immutable AnchorToken <: Token
     span::Span
-    value::String
+    value::AbstractString
 end
 
 # '!handle!suffix'
@@ -108,9 +108,9 @@ end
 # A scalar.
 immutable ScalarToken <: Token
     span::Span
-    value::String
+    value::AbstractString
     plain::Bool
-    style::Union(Char, Nothing)
+    style::Union{Char, Void}
 end
 
 


### PR DESCRIPTION
Fixes #24. WIP because some tests fail.

All warnings gone on 0.4.0-rc2:

```julia
               _
   _       _ _(_)_     |  A fresh approach to technical computing
  (_)     | (_) (_)    |  Documentation: http://docs.julialang.org
   _ _   _| |_  __ _   |  Type "?help" for help.
  | | | | | | |/ _` |  |
  | | |_| | | | (_| |  |  Version 0.4.0-rc2+10 (2015-09-20 15:38 UTC)
 _/ |\__'_|_|_|\__'_|  |  Commit d8930a0* (1 day old release-0.4)
|__/                   |  x86_64-apple-darwin14.5.0

julia> using YAML
INFO: Precompiling module YAML...

julia>
```

Running tests throws error at test `spec-02-21`

```julia
julia> for test in tests
           data = YAML.load_file(joinpath(testdir, string(test, ".data")))
           expected = evalfile(joinpath(testdir, string(test, ".expected")))
           if !equivalent(data, expected)
               @printf("%s: FAILED\n", test)
               @printf("Expected:\n%s\nParsed:\n%s\n",
                       expected, data)
           else
               @printf("%s: PASSED\n", test)
           end
       end
spec-02-01: PASSED
spec-02-02: PASSED
spec-02-03: PASSED
spec-02-04: PASSED
spec-02-05: PASSED
spec-02-06: PASSED
spec-02-07: PASSED
spec-02-08: PASSED
spec-02-09: PASSED
spec-02-10: PASSED
spec-02-11: PASSED
spec-02-12: PASSED
spec-02-13: PASSED
spec-02-14: PASSED
spec-02-15: PASSED
spec-02-16: PASSED
spec-02-17: PASSED
spec-02-18: PASSED
spec-02-19: PASSED
spec-02-20: PASSED
spec-02-21: PASSED
ERROR: MethodError: `convert` has no method matching convert(::Type{AbstractString}, ::SubString{UTF8String}, ::ASCIIString)
This may have arisen from a call to the constructor AbstractString(...),
since type constructors fall back to convert methods.
Closest candidates are:
  convert{T}(::Type{T}, ::T)
  call{T}(::Type{T}, ::Any)
  convert{T<:AbstractString,S<:Union{Char,Int32,UInt32}}(::Type{T<:AbstractString}, ::AbstractArray{S<:Union{Char,Int32,UInt32},1})
  ...
 in call at essentials.jl:57
 in construct_yaml_timestamp at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:275
 in construct_object at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:77
 in construct_mapping at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:147
 in construct_yaml_map at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:325
 in construct_object at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:77
 in construct_document at /Users/rzwitc200/.julia/v0.4/YAML/src/constructor.jl:33
 in load_file at /Users/rzwitc200/.julia/v0.4/YAML/src/YAML.jl:76
 [inlined code] from none:2
 in anonymous at no file:0

julia> 
```

