### PR TITLE
Some fixes for tag parsing

### DIFF
--- a/src/composer.jl
+++ b/src/composer.jl
@@ -17,6 +17,13 @@ immutable ComposerError
     end
 end
 
+function show(io::IO, error::ComposerError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type Composer
     input::EventStream
@@ -54,7 +61,7 @@ function compose_node(composer::Composer, parent::(@compat Union{Node, Void}),
         forward!(composer.input)
         anchor = event.anchor
         if !haskey(composer.anchors, anchor)
-            throw(ComposerError(nothing, nothing, "found undefined alias $(anchor)",
+            throw(ComposerError(nothing, nothing, "found undefined alias '$(anchor)'",
                                 event.start_mark))
         end
         return composer.anchors[anchor]
@@ -64,7 +71,7 @@ function compose_node(composer::Composer, parent::(@compat Union{Node, Void}),
     if !is(anchor, nothing)
         if haskey(composer.anchors, anchor)
             throw(ComposerError(
-                "found duplicate anchor $(anchor); first occurance",
+                "found duplicate anchor '$(anchor)'; first occurance",
                 composer.anchors[anchor].start_mark, "second occurence",
                 event.start_mark))
         end

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -15,6 +15,13 @@ immutable ConstructorError
 
 end
 
+function show(io::IO, error::ConstructorError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type Constructor
     constructed_objects::Dict{Node, Any}
@@ -334,7 +341,7 @@ end
 
 function construct_undefined(constructor::Constructor, node::Node)
     throw(ConstructorError(nothing, nothing,
-        "could not determine a constructor for the tag $(node.tag)",
+        "could not determine a constructor for the tag '$(node.tag)'",
         node.start_mark))
 end
 

--- a/src/events.jl
+++ b/src/events.jl
@@ -18,7 +18,7 @@ immutable DocumentStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
     explicit::Bool
-    version::(@compat Union{AbstractString, Void})
+    version::(@compat Union{Tuple, Void})
     tags::(@compat Union{Dict{AbstractString, AbstractString}, Void})
 
     function DocumentStartEvent(start_mark::Mark,end_mark::Mark,

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -91,7 +91,7 @@ function process_directives(stream::EventStream)
                     token.start_mark))
             end
             stream.yaml_version = token.value
-        elseif taken.name == "TAG"
+        elseif token.name == "TAG"
             handle, prefix = token.value
             if haskey(stream.tag_handles, handle)
                 throw(ParserError(nothing, nothing,

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -18,6 +18,13 @@ immutable ParserError
     end
 end
 
+function show(io::IO, error::ParserError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type EventStream
     input::TokenStream

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -37,6 +37,13 @@ immutable ScannerError <: Exception
     problem_mark::Mark
 end
 
+function show(io::IO, error::ScannerError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 include("tokens.jl")
 
@@ -812,7 +819,7 @@ function scan_directive_name(stream::TokenStream, start_mark::Mark)
 
     if length == 0
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected alphanumeric character, but found $(c)",
+                           "expected alphanumeric character, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -822,7 +829,7 @@ function scan_directive_name(stream::TokenStream, start_mark::Mark)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected alphanumeric character, but found $(c)",
+                           "expected alphanumeric character, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -838,14 +845,14 @@ function scan_yaml_directive_value(stream::TokenStream, start_mark::Mark)
     major = scan_yaml_directive_number(stream, start_mark)
     if peek(stream.input) != '.'
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit or '.' but found $(peek(stream.input))",
+                           "expected '.' but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     forwardchars!(stream)
     minor = scan_yaml_directive_number(stream, start_mark)
     if !in(peek(stream.input), "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit or ' ', but found $(peek(stream.input))",
+                           "expected ' ' or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     return (major, minor)
@@ -855,7 +862,7 @@ end
 function scan_yaml_directive_number(stream::TokenStream, start_mark::Mark)
     if !isdigit(peek(stream.input))
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit, but found $(peek(stream.input))",
+                           "expected a digit, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     length = 0
@@ -876,7 +883,7 @@ function scan_tag_directive_handle(stream::TokenStream, start_mark::Mark)
     value = scan_tag_handle(stream, "directive", start_mark)
     if peek(stream.input) != ' '
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected ' ', but found $(peek(stream.input))",
+                           "expected ' ', but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     value
@@ -910,10 +917,10 @@ function scan_directive_ignored_line(stream::TokenStream, start_mark::Mark)
     end
     if !in(peek(stream.input), "\0\r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a comment or a line break, but found $(peek(stream.input))",
+                           "expected a comment or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
-     end
-     scan_line_break(stream)
+    end
+    scan_line_break(stream)
 end
 
 
@@ -935,14 +942,14 @@ function scan_anchor(stream::TokenStream, tokentype)
 
     if length == 0
         throw(ScannerError("while scanning an $(name)", start_mark,
-                           "expected an alphanumeric character, but found $(peek(stream.input))",
+                           "expected an alphanumeric character, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     value = prefix(stream.input, length)
     forwardchars!(stream, length)
     if !in(peek(stream.input), "\0 \t\r\n\u0085\u2028\u2029?:,]}%@`")
         throw(ScannerError("while scanning an $(name)", start_mark,
-                           "expected an alphanumeric character, but found $(peek(stream.input))",
+                           "expected an alphanumeric character, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     end_mark = get_mark(stream)
@@ -959,7 +966,7 @@ function scan_tag(stream::TokenStream)
         suffix = scan_tag_uri(stream, "tag", start_mark)
         if peek(stream.input) != '>'
             throw(ScannerError("while parsing a tag", start_mark,
-                               "expected '>', but found $(peek(stream.input))",
+                               "expected '>', but found '$(peek(stream.input))'",
                                get_mark(stream)))
         end
         forwardchars!(stream)
@@ -990,7 +997,7 @@ function scan_tag(stream::TokenStream)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a tag", start_mark,
-                           "expected ' ', but found $(c)",
+                           "expected ' ' or a line break, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -1073,7 +1080,7 @@ function scan_block_scalar_ignored_line(stream::TokenStream, start_mark::Mark)
 
     if !in(peek(stream.input), "\0\r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a block scalal", start_mark,
-                           "expected a commend or a line break, but found $(peek(stream.input))",
+                           "expected a comment or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
 
@@ -1116,7 +1123,7 @@ function scan_block_scalar_indicators(stream::TokenStream, start_mark::Mark)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a block scalar", start_mark,
-            "expected chomping or indentation indicators, but found $(c)",
+            "expected chomping or indentation indicators, but found '$(c)'",
             get_mark(stream)))
     end
 
@@ -1242,7 +1249,7 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
                                            start_mark,
                                            string("expected escape sequence of",
                                                   " $(length) hexadecimal",
-                                                  "digits, but found $(c)"),
+                                                  "digits, but found '$(c)'"),
                                            get_mark(stream)))
                     end
                 end
@@ -1254,7 +1261,7 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
             else
                 throw(ScannerError("while scanning a double-quoted scalar",
                                    start_mark,
-                                   "found unknown escape character $(c)",
+                                   "found unknown escape character '$(c)'",
                                    get_mark(stream)))
             end
         else
@@ -1435,7 +1442,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
     c = peek(stream.input)
     if c != '!'
         throw(ScannerError("while scanning a $(name)", start_mark,
-                           "expected '!', but found $(c)", get_mark(stream)))
+                           "expected '!', but found '$(c)'", get_mark(stream)))
     end
     length = 1
     c = peek(stream.input, length)
@@ -1448,7 +1455,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
         if c != '!'
             forwardchars!(stream, length)
             throw(ScannerError("while scanning a $(name)", start_mark,
-                               "expected '!', but found $(c)",
+                               "expected '!', but found '$(c)'",
                                get_mark(stream)))
         end
         length += 1
@@ -1484,7 +1491,7 @@ function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mar
 
     if isempty(chunks)
         throw(ScannerError("while parsing a $(name)", start_mark,
-                           "expected URI, but found $(c)",
+                           "expected URI, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -1502,7 +1509,7 @@ function scan_uri_escapes(stream::TokenStream, name::AbstractString, start_mark:
                 throw(ScannerError("while scanning a $(name)", start_mark,
                                    string("expected URI escape sequence of",
                                           " 2 hexadecimal digits, but found",
-                                          " $(peek(stream.input, k))"),
+                                          " '$(peek(stream.input, k))'"),
                                    get_mark(stream)))
             end
         end


### PR DESCRIPTION
Hello,

I was starting an long-term investigation into seeing what would be required to parse YAML documents into native Julia objects and discovered there was some broken code in the tag parsing/composition, both in tag annotations and in the tag directive. I believe this should fix all of those issues.

Previously, loading the `spec-02-24.data` test document was failing at the parsing stage and now it only fails because it can't find a constructor for the custom tag.

Let me know if anything I did was confusing or incorrect and I'd be happy to get it fixed.

Thanks for the great package!
