### PR TITLE
Tags

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -58,13 +58,13 @@ done(it::YAMLDocIterator, state) = it.next_doc === nothing
 
 load_all(input::IO) = YAMLDocIterator(input)
 
-function load(input::AbstractString, more_constructors::_constructor=nothing)
+function load(input::String, more_constructors::_constructor=nothing)
     load(IOBuffer(input), more_constructors)
 end
 
-load_all(input::AbstractString) = load_all(IOBuffer(input))
+load_all(input::String) = load_all(IOBuffer(input))
 
-function load_file(filename::AbstractString, more_constructors::_constructor=nothing)
+function load_file(filename::String, more_constructors::_constructor=nothing)
     input = open(filename)
     data = load(input, more_constructors)
     close(input)
@@ -72,7 +72,7 @@ function load_file(filename::AbstractString, more_constructors::_constructor=not
 end
 
 
-function load_all_file(filename::AbstractString)
+function load_all_file(filename::String)
     input = open(filename)
     data = load_all(input)
     close(input)

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -1,89 +1,91 @@
 VERSION >= v"0.4-" && __precompile__()
 
 module YAML
-    import Base: start, next, done, isempty, length, show
-    import Codecs
-    using Compat
 
-    if VERSION < v"0.4-dev"
-        using Dates
-    end
+import Base: start, next, done, isempty, length, show
+import Codecs
+using Compat
 
-    include("scanner.jl")
-    include("parser.jl")
-    include("composer.jl")
-    include("constructor.jl")
+if VERSION < v"0.4-dev"
+    using Dates
+end
 
-
-    function load(ts::TokenStream)
-        events = EventStream(ts)
-        node = compose(events)
-        return construct_document(Constructor(), node)
-    end
+include("scanner.jl")
+include("parser.jl")
+include("composer.jl")
+include("constructor.jl")
 
 
-    function load(input::IO)
-        return load(TokenStream(input))
-    end
+function load(ts::TokenStream)
+    events = EventStream(ts)
+    node = compose(events)
+    return construct_document(Constructor(), node)
+end
 
 
-    type YAMLDocIterator
-        input::IO
-        ts::TokenStream
-        next_doc
-
-        function YAMLDocIterator(input::IO)
-            it = new(input, TokenStream(input), nothing)
-            it.next_doc = eof(it.input) ? nothing : load(it.ts)
-            return it
-        end
-    end
+function load(input::IO)
+    return load(TokenStream(input))
+end
 
 
-    function start(it::YAMLDocIterator)
-        nothing
-    end
+type YAMLDocIterator
+    input::IO
+    ts::TokenStream
+    next_doc
 
-
-    function next(it::YAMLDocIterator, state)
-        doc = it.next_doc
-        if eof(it.input)
-            it.next_doc = nothing
-        else
-            reset!(it.ts)
-            it.next_doc = load(it.ts)
-        end
-        return doc, nothing
-    end
-
-    function done(it::YAMLDocIterator, state)
-        return it.next_doc === nothing
-    end
-
-
-    function load_all(input::IO)
-        YAMLDocIterator(input)
-    end
-
-
-
-    load(input::AbstractString) = load(IOBuffer(input))
-    load_all(input::AbstractString) = load_all(IOBuffer(input))
-
-
-    function load_file(filename::AbstractString)
-        input = open(filename)
-        data = load(input)
-        close(input)
-        data
-    end
-
-
-    function load_all_file(filename::AbstractString)
-        input = open(filename)
-        data = load_all(input)
-        close(input)
-        data
+    function YAMLDocIterator(input::IO)
+        it = new(input, TokenStream(input), nothing)
+        it.next_doc = eof(it.input) ? nothing : load(it.ts)
+        return it
     end
 end
+
+
+function start(it::YAMLDocIterator)
+    nothing
+end
+
+
+function next(it::YAMLDocIterator, state)
+    doc = it.next_doc
+    if eof(it.input)
+        it.next_doc = nothing
+    else
+        reset!(it.ts)
+        it.next_doc = load(it.ts)
+    end
+    return doc, nothing
+end
+
+function done(it::YAMLDocIterator, state)
+    return it.next_doc === nothing
+end
+
+
+function load_all(input::IO)
+    YAMLDocIterator(input)
+end
+
+
+
+load(input::AbstractString) = load(IOBuffer(input))
+load_all(input::AbstractString) = load_all(IOBuffer(input))
+
+
+function load_file(filename::AbstractString)
+    input = open(filename)
+    data = load(input)
+    close(input)
+    data
+end
+
+
+function load_all_file(filename::AbstractString)
+    input = open(filename)
+    data = load_all(input)
+    close(input)
+    data
+end
+
+end  # module
 

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -5,7 +5,7 @@ module YAML
 import Base: start, next, done, isempty, length, show
 import Codecs
 using Compat
-using Compat: String
+import Compat: String
 
 if VERSION < v"0.4-dev"
     using Dates
@@ -16,7 +16,7 @@ include("parser.jl")
 include("composer.jl")
 include("constructor.jl")
 
-typealias _constructor @compat Union{Void,Dict{ASCIIString,Function}}
+typealias _constructor @compat Union{Void,Dict{String,Function}}
 
 function load(ts::TokenStream, more_constructors::_constructor=nothing)
     events = EventStream(ts)

--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -16,7 +16,7 @@ include("parser.jl")
 include("composer.jl")
 include("constructor.jl")
 
-typealias _constructor @compat Union{Void,Dict{String,Function}}
+typealias _constructor @compat Union{Void,Dict}
 
 function load(ts::TokenStream, more_constructors::_constructor=nothing)
     events = EventStream(ts)

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -17,6 +17,13 @@ immutable ComposerError
     end
 end
 
+function show(io::IO, error::ComposerError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type Composer
     input::EventStream
@@ -54,7 +61,7 @@ function compose_node(composer::Composer, parent::(@compat Union{Node, Void}),
         forward!(composer.input)
         anchor = event.anchor
         if !haskey(composer.anchors, anchor)
-            throw(ComposerError(nothing, nothing, "found undefined alias $(anchor)",
+            throw(ComposerError(nothing, nothing, "found undefined alias '$(anchor)'",
                                 event.start_mark))
         end
         return composer.anchors[anchor]
@@ -64,7 +71,7 @@ function compose_node(composer::Composer, parent::(@compat Union{Node, Void}),
     if !is(anchor, nothing)
         if haskey(composer.anchors, anchor)
             throw(ComposerError(
-                "found duplicate anchor $(anchor); first occurance",
+                "found duplicate anchor '$(anchor)'; first occurance",
                 composer.anchors[anchor].start_mark, "second occurence",
                 event.start_mark))
         end

--- a/src/composer.jl
+++ b/src/composer.jl
@@ -4,11 +4,11 @@ include("resolver.jl")
 
 
 immutable ComposerError
-    context::(@compat Union{AbstractString, Void})
+    context::(@compat Union{String, Void})
     context_mark::(@compat Union{Mark, Void})
-    problem::(@compat Union{AbstractString, Void})
+    problem::(@compat Union{String, Void})
     problem_mark::(@compat Union{Mark, Void})
-    note::(@compat Union{AbstractString, Void})
+    note::(@compat Union{String, Void})
 
     function ComposerError(context=nothing, context_mark=nothing,
                            problem=nothing, problem_mark=nothing,
@@ -27,13 +27,13 @@ end
 
 type Composer
     input::EventStream
-    anchors::Dict{AbstractString, Node}
+    anchors::Dict{String, Node}
     resolver::Resolver
 end
 
 
 function compose(events)
-    composer = Composer(events, Dict{AbstractString, Node}(), Resolver())
+    composer = Composer(events, Dict{String, Node}(), Resolver())
     @assert typeof(forward!(composer.input)) == StreamStartEvent
     node = compose_document(composer)
     if typeof(peek(composer.input)) == StreamEndEvent
@@ -90,7 +90,7 @@ function compose_node(composer::Composer, parent::(@compat Union{Node, Void}),
 end
 
 
-function compose_scalar_node(composer::Composer, anchor::(@compat Union{AbstractString, Void}))
+function compose_scalar_node(composer::Composer, anchor::(@compat Union{String, Void}))
     event = forward!(composer.input)
     tag = event.tag
     if tag === nothing || tag == "!"
@@ -108,7 +108,7 @@ function compose_scalar_node(composer::Composer, anchor::(@compat Union{Abstract
 end
 
 
-function compose_sequence_node(composer::Composer, anchor::(@compat Union{AbstractString, Void}))
+function compose_sequence_node(composer::Composer, anchor::(@compat Union{String, Void}))
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"
@@ -135,7 +135,7 @@ function compose_sequence_node(composer::Composer, anchor::(@compat Union{Abstra
 end
 
 
-function compose_mapping_node(composer::Composer, anchor::(@compat Union{AbstractString, Void}))
+function compose_mapping_node(composer::Composer, anchor::(@compat Union{String, Void}))
     start_event = forward!(composer.input)
     tag = start_event.tag
     if tag === nothing || tag == "!"

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -15,6 +15,13 @@ immutable ConstructorError
 
 end
 
+function show(io::IO, error::ConstructorError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type Constructor
     constructed_objects::Dict{Node, Any}
@@ -334,7 +341,7 @@ end
 
 function construct_undefined(constructor::Constructor, node::Node)
     throw(ConstructorError(nothing, nothing,
-        "could not determine a constructor for the tag $(node.tag)",
+        "could not determine a constructor for the tag '$(node.tag)'",
         node.start_mark))
 end
 

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -29,12 +29,14 @@ type Constructor
     deep_construct::Bool
     yaml_constructors::Dict{(@compat Union{AbstractString, Void}), Function}
 
-    function Constructor()
+    function Constructor(more_constructors::Dict{ASCIIString,Function})
         new(Dict{Node, Any}(), Set{Node}(), false,
-            copy(default_yaml_constructors))
+            merge(copy(default_yaml_constructors), more_constructors))
     end
 end
 
+Constructor() = Constructor(Dict{ASCIIString,Function}())
+Constructor(::Void) = Constructor(Dict{ASCIIString,Function}())
 
 function construct_document(constructor::Constructor, node::Node)
     data = construct_object(constructor, node)
@@ -351,7 +353,6 @@ function construct_yaml_binary(constructor::Constructor, node::Node)
     Codecs.decode(Codecs.Base64, value)
 end
 
-
 const default_yaml_constructors = @compat Dict{(@compat Union{AbstractString, Void}), Function}(
         "tag:yaml.org,2002:null"      => construct_yaml_null,
         "tag:yaml.org,2002:bool"      => construct_yaml_bool,
@@ -365,7 +366,5 @@ const default_yaml_constructors = @compat Dict{(@compat Union{AbstractString, Vo
         "tag:yaml.org,2002:str"       => construct_yaml_str,
         "tag:yaml.org,2002:seq"       => construct_yaml_seq,
         "tag:yaml.org,2002:map"       => construct_yaml_map,
-        nothing                       => construct_undefined
+        nothing                       => construct_undefined,
     )
-
-

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -1,11 +1,11 @@
 
 
 immutable ConstructorError
-    context::(@compat Union{AbstractString, Void})
+    context::(@compat Union{String, Void})
     context_mark::(@compat Union{Mark, Void})
-    problem::(@compat Union{AbstractString, Void})
+    problem::(@compat Union{String, Void})
     problem_mark::(@compat Union{Mark, Void})
-    note::(@compat Union{AbstractString, Void})
+    note::(@compat Union{String, Void})
 
     function ConstructorError(context=nothing, context_mark=nothing,
                               problem=nothing, problem_mark=nothing,
@@ -27,16 +27,16 @@ type Constructor
     constructed_objects::Dict{Node, Any}
     recursive_objects::Set{Node}
     deep_construct::Bool
-    yaml_constructors::Dict{(@compat Union{AbstractString, Void}), Function}
+    yaml_constructors::Dict{(@compat Union{String, Void}), Function}
 
-    function Constructor(more_constructors::Dict{ASCIIString,Function})
+    function Constructor(more_constructors::Dict{String,Function})
         new(Dict{Node, Any}(), Set{Node}(), false,
             merge(copy(default_yaml_constructors), more_constructors))
     end
 end
 
-Constructor() = Constructor(Dict{ASCIIString,Function}())
-Constructor(::Void) = Constructor(Dict{ASCIIString,Function}())
+Constructor() = Constructor(Dict{String,Function}())
+Constructor(::Void) = Constructor(Dict{String,Function}())
 
 function construct_document(constructor::Constructor, node::Node)
     data = construct_object(constructor, node)
@@ -189,7 +189,7 @@ function construct_yaml_int(constructor::Constructor, node::Node)
         # TODO
         #throw(ConstructorError(nothing, nothing,
             #"sexagesimal integers not yet implemented", node.start_mark))
-        warn("sexagesimal integers not yet implemented. Returning AbstractString.")
+        warn("sexagesimal integers not yet implemented. Returning String.")
         return value
     end
 
@@ -211,7 +211,7 @@ function construct_yaml_float(constructor::Constructor, node::Node)
         # TODO
         # throw(ConstructorError(nothing, nothing,
         #     "sexagesimal floats not yet implemented", node.start_mark))
-        warn("sexagesimal floats not yet implemented. Returning AbstractString.")
+        warn("sexagesimal floats not yet implemented. Returning String.")
         return value
     end
 
@@ -353,7 +353,7 @@ function construct_yaml_binary(constructor::Constructor, node::Node)
     Codecs.decode(Codecs.Base64, value)
 end
 
-const default_yaml_constructors = @compat Dict{(@compat Union{AbstractString, Void}), Function}(
+const default_yaml_constructors = @compat Dict{(@compat Union{String, Void}), Function}(
         "tag:yaml.org,2002:null"      => construct_yaml_null,
         "tag:yaml.org,2002:bool"      => construct_yaml_bool,
         "tag:yaml.org,2002:int"       => construct_yaml_int,

--- a/src/events.jl
+++ b/src/events.jl
@@ -18,7 +18,7 @@ immutable DocumentStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
     explicit::Bool
-    version::(@compat Union{AbstractString, Void})
+    version::(@compat Union{Tuple, Void})
     tags::(@compat Union{Dict{AbstractString, AbstractString}, Void})
 
     function DocumentStartEvent(start_mark::Mark,end_mark::Mark,

--- a/src/events.jl
+++ b/src/events.jl
@@ -4,7 +4,7 @@ abstract Event
 immutable StreamStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    encoding::AbstractString
+    encoding::String
 end
 
 
@@ -19,7 +19,7 @@ immutable DocumentStartEvent <: Event
     end_mark::Mark
     explicit::Bool
     version::(@compat Union{Tuple, Void})
-    tags::(@compat Union{Dict{AbstractString, AbstractString}, Void})
+    tags::(@compat Union{Dict{String, String}, Void})
 
     function DocumentStartEvent(start_mark::Mark,end_mark::Mark,
                                 explicit::Bool, version=nothing,
@@ -39,17 +39,17 @@ end
 immutable AliasEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::(@compat Union{AbstractString, Void})
+    anchor::(@compat Union{String, Void})
 end
 
 
 immutable ScalarEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::(@compat Union{AbstractString, Void})
-    tag::(@compat Union{AbstractString, Void})
+    anchor::(@compat Union{String, Void})
+    tag::(@compat Union{String, Void})
     implicit::Tuple
-    value::AbstractString
+    value::String
     style::(@compat Union{Char, Void})
 end
 
@@ -57,8 +57,8 @@ end
 immutable SequenceStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::(@compat Union{AbstractString, Void})
-    tag::(@compat Union{AbstractString, Void})
+    anchor::(@compat Union{String, Void})
+    tag::(@compat Union{String, Void})
     implicit::Bool
     flow_style::Bool
 end
@@ -73,8 +73,8 @@ end
 immutable MappingStartEvent <: Event
     start_mark::Mark
     end_mark::Mark
-    anchor::(@compat Union{AbstractString, Void})
-    tag::(@compat Union{AbstractString, Void})
+    anchor::(@compat Union{String, Void})
+    tag::(@compat Union{String, Void})
     implicit::Bool
     flow_style::Bool
 end

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -2,8 +2,8 @@
 abstract Node
 
 type ScalarNode <: Node
-    tag::AbstractString
-    value::AbstractString
+    tag::String
+    value::String
     start_mark::(@compat Union{Mark, Void})
     end_mark::(@compat Union{Mark, Void})
     style::(@compat Union{Char, Void})
@@ -11,7 +11,7 @@ end
 
 
 type SequenceNode <: Node
-    tag::AbstractString
+    tag::String
     value::Vector
     start_mark::(@compat Union{Mark, Void})
     end_mark::(@compat Union{Mark, Void})
@@ -20,7 +20,7 @@ end
 
 
 type MappingNode <: Node
-    tag::AbstractString
+    tag::String
     value::Vector
     start_mark::(@compat Union{Mark, Void})
     end_mark::(@compat Union{Mark, Void})

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -91,7 +91,7 @@ function process_directives(stream::EventStream)
                     token.start_mark))
             end
             stream.yaml_version = token.value
-        elseif taken.name == "TAG"
+        elseif token.name == "TAG"
             handle, prefix = token.value
             if haskey(stream.tag_handles, handle)
                 throw(ParserError(nothing, nothing,

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -18,6 +18,13 @@ immutable ParserError
     end
 end
 
+function show(io::IO, error::ParserError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 type EventStream
     input::TokenStream

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -1,15 +1,15 @@
 
 include("events.jl")
 
-const DEFAULT_TAGS = @compat Dict{AbstractString,AbstractString}("!" => "!", "!!" => "tag:yaml.org,2002:")
+const DEFAULT_TAGS = @compat Dict{String,String}("!" => "!", "!!" => "tag:yaml.org,2002:")
 
 
 immutable ParserError
-    context::(@compat Union{AbstractString, Void})
+    context::(@compat Union{String, Void})
     context_mark::(@compat Union{Mark, Void})
-    problem::(@compat Union{AbstractString, Void})
+    problem::(@compat Union{String, Void})
     problem_mark::(@compat Union{Mark, Void})
-    note::(@compat Union{AbstractString, Void})
+    note::(@compat Union{String, Void})
 
     function ParserError(context=nothing, context_mark=nothing,
                          problem=nothing, problem_mark=nothing,
@@ -33,12 +33,12 @@ type EventStream
     states::Vector{Function}
     marks::Vector{Mark}
     yaml_version::(@compat Union{Tuple, Void})
-    tag_handles::Dict{AbstractString, AbstractString}
+    tag_handles::Dict{String, String}
     end_of_stream::(@compat Union{StreamEndEvent, Void})
 
     function EventStream(input::TokenStream)
         new(input, nothing, parse_stream_start, Function[], Mark[],
-            nothing, Dict{AbstractString, AbstractString}(), nothing)
+            nothing, Dict{String, String}(), nothing)
     end
 end
 
@@ -82,7 +82,7 @@ end
 
 function process_directives(stream::EventStream)
     stream.yaml_version = nothing
-    stream.tag_handles = Dict{AbstractString, AbstractString}()
+    stream.tag_handles = Dict{String, String}()
     while typeof(peek(stream.input)) == DirectiveToken
         token = forward!(stream.input)
         if token.name == "YAML"

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -31,9 +31,9 @@ end
 
 # Errors thrown by the scanner.
 immutable ScannerError <: Exception
-    context::(@compat Union{AbstractString, Void})
+    context::(@compat Union{String, Void})
     context_mark::(@compat Union{Mark, Void})
-    problem::AbstractString
+    problem::String
     problem_mark::Mark
 end
 
@@ -1438,7 +1438,7 @@ function scan_plain_spaces(stream::TokenStream, indent::Integer,
 end
 
 
-function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_tag_handle(stream::TokenStream, name::String, start_mark::Mark)
     c = peek(stream.input)
     if c != '!'
         throw(ScannerError("while scanning a $(name)", start_mark,
@@ -1467,7 +1467,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
 end
 
 
-function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_tag_uri(stream::TokenStream, name::String, start_mark::Mark)
     chunks = Any[]
     length = 0
     c = peek(stream.input, length)
@@ -1499,7 +1499,7 @@ function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mar
 end
 
 
-function scan_uri_escapes(stream::TokenStream, name::AbstractString, start_mark::Mark)
+function scan_uri_escapes(stream::TokenStream, name::String, start_mark::Mark)
     bytes = Any[]
     mark = get_mark(stream)
     while peek(stream.input) == '%'

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -37,6 +37,13 @@ immutable ScannerError <: Exception
     problem_mark::Mark
 end
 
+function show(io::IO, error::ScannerError)
+    if error.context != nothing
+        print(io, error.context, " at ", error.context_mark, ": ")
+    end
+    print(io, error.problem, " at ", error.problem_mark)
+end
+
 
 include("tokens.jl")
 
@@ -812,7 +819,7 @@ function scan_directive_name(stream::TokenStream, start_mark::Mark)
 
     if length == 0
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected alphanumeric character, but found $(c)",
+                           "expected alphanumeric character, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -822,7 +829,7 @@ function scan_directive_name(stream::TokenStream, start_mark::Mark)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected alphanumeric character, but found $(c)",
+                           "expected alphanumeric character, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -838,14 +845,14 @@ function scan_yaml_directive_value(stream::TokenStream, start_mark::Mark)
     major = scan_yaml_directive_number(stream, start_mark)
     if peek(stream.input) != '.'
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit or '.' but found $(peek(stream.input))",
+                           "expected '.' but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     forwardchars!(stream)
     minor = scan_yaml_directive_number(stream, start_mark)
     if !in(peek(stream.input), "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit or ' ', but found $(peek(stream.input))",
+                           "expected ' ' or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     return (major, minor)
@@ -855,7 +862,7 @@ end
 function scan_yaml_directive_number(stream::TokenStream, start_mark::Mark)
     if !isdigit(peek(stream.input))
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a digit, but found $(peek(stream.input))",
+                           "expected a digit, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     length = 0
@@ -876,7 +883,7 @@ function scan_tag_directive_handle(stream::TokenStream, start_mark::Mark)
     value = scan_tag_handle(stream, "directive", start_mark)
     if peek(stream.input) != ' '
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected ' ', but found $(peek(stream.input))",
+                           "expected ' ', but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     value
@@ -910,10 +917,10 @@ function scan_directive_ignored_line(stream::TokenStream, start_mark::Mark)
     end
     if !in(peek(stream.input), "\0\r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a directive", start_mark,
-                           "expected a comment or a line break, but found $(peek(stream.input))",
+                           "expected a comment or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
-     end
-     scan_line_break(stream)
+    end
+    scan_line_break(stream)
 end
 
 
@@ -935,14 +942,14 @@ function scan_anchor(stream::TokenStream, tokentype)
 
     if length == 0
         throw(ScannerError("while scanning an $(name)", start_mark,
-                           "expected an alphanumeric character, but found $(peek(stream.input))",
+                           "expected an alphanumeric character, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     value = prefix(stream.input, length)
     forwardchars!(stream, length)
     if !in(peek(stream.input), "\0 \t\r\n\u0085\u2028\u2029?:,]}%@`")
         throw(ScannerError("while scanning an $(name)", start_mark,
-                           "expected an alphanumeric character, but found $(peek(stream.input))",
+                           "expected an alphanumeric character, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
     end_mark = get_mark(stream)
@@ -959,7 +966,7 @@ function scan_tag(stream::TokenStream)
         suffix = scan_tag_uri(stream, "tag", start_mark)
         if peek(stream.input) != '>'
             throw(ScannerError("while parsing a tag", start_mark,
-                               "expected '>', but found $(peek(stream.input))",
+                               "expected '>', but found '$(peek(stream.input))'",
                                get_mark(stream)))
         end
         forwardchars!(stream)
@@ -990,7 +997,7 @@ function scan_tag(stream::TokenStream)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a tag", start_mark,
-                           "expected ' ', but found $(c)",
+                           "expected ' ' or a line break, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -1073,7 +1080,7 @@ function scan_block_scalar_ignored_line(stream::TokenStream, start_mark::Mark)
 
     if !in(peek(stream.input), "\0\r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a block scalal", start_mark,
-                           "expected a commend or a line break, but found $(peek(stream.input))",
+                           "expected a comment or a line break, but found '$(peek(stream.input))'",
                            get_mark(stream)))
     end
 
@@ -1116,7 +1123,7 @@ function scan_block_scalar_indicators(stream::TokenStream, start_mark::Mark)
     c = peek(stream.input)
     if !in(c, "\0 \r\n\u0085\u2028\u2029")
         throw(ScannerError("while scanning a block scalar", start_mark,
-            "expected chomping or indentation indicators, but found $(c)",
+            "expected chomping or indentation indicators, but found '$(c)'",
             get_mark(stream)))
     end
 
@@ -1242,7 +1249,7 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
                                            start_mark,
                                            string("expected escape sequence of",
                                                   " $(length) hexadecimal",
-                                                  "digits, but found $(c)"),
+                                                  "digits, but found '$(c)'"),
                                            get_mark(stream)))
                     end
                 end
@@ -1254,7 +1261,7 @@ function scan_flow_scalar_non_spaces(stream::TokenStream, double::Bool,
             else
                 throw(ScannerError("while scanning a double-quoted scalar",
                                    start_mark,
-                                   "found unknown escape character $(c)",
+                                   "found unknown escape character '$(c)'",
                                    get_mark(stream)))
             end
         else
@@ -1435,7 +1442,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
     c = peek(stream.input)
     if c != '!'
         throw(ScannerError("while scanning a $(name)", start_mark,
-                           "expected '!', but found $(c)", get_mark(stream)))
+                           "expected '!', but found '$(c)'", get_mark(stream)))
     end
     length = 1
     c = peek(stream.input, length)
@@ -1448,7 +1455,7 @@ function scan_tag_handle(stream::TokenStream, name::AbstractString, start_mark::
         if c != '!'
             forwardchars!(stream, length)
             throw(ScannerError("while scanning a $(name)", start_mark,
-                               "expected '!', but found $(c)",
+                               "expected '!', but found '$(c)'",
                                get_mark(stream)))
         end
         length += 1
@@ -1484,7 +1491,7 @@ function scan_tag_uri(stream::TokenStream, name::AbstractString, start_mark::Mar
 
     if isempty(chunks)
         throw(ScannerError("while parsing a $(name)", start_mark,
-                           "expected URI, but found $(c)",
+                           "expected URI, but found '$(c)'",
                            get_mark(stream)))
     end
 
@@ -1502,7 +1509,7 @@ function scan_uri_escapes(stream::TokenStream, name::AbstractString, start_mark:
                 throw(ScannerError("while scanning a $(name)", start_mark,
                                    string("expected URI escape sequence of",
                                           " 2 hexadecimal digits, but found",
-                                          " $(peek(stream.input, k))"),
+                                          " '$(peek(stream.input, k))'"),
                                    get_mark(stream)))
             end
         end

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -7,7 +7,7 @@ abstract Token
 # The '%YAML' directive.
 immutable DirectiveToken <: Token
     span::Span
-    name::AbstractString
+    name::String
     value::(@compat Union{Tuple, Void})
 end
 
@@ -24,7 +24,7 @@ end
 # The stream start
 immutable StreamStartToken <: Token
     span::Span
-    encoding::AbstractString
+    encoding::String
 end
 
 # The stream end
@@ -90,13 +90,13 @@ end
 # '*anchor'
 immutable AliasToken <: Token
     span::Span
-    value::AbstractString
+    value::String
 end
 
 # '&anchor'
 immutable AnchorToken <: Token
     span::Span
-    value::AbstractString
+    value::String
 end
 
 # '!handle!suffix'
@@ -108,7 +108,7 @@ end
 # A scalar.
 immutable ScalarToken <: Token
     span::Span
-    value::AbstractString
+    value::String
     plain::Bool
     style::(@compat Union{Char, Void})
 end

--- a/test/ar1.data
+++ b/test/ar1.data
@@ -1,0 +1,3 @@
+process: !AR1
+    rho: 0.95
+    sigma: 0.1

--- a/test/ar1.expected
+++ b/test/ar1.expected
@@ -1,0 +1,1 @@
+Dict("process" => Dict("sigma" => 0.1, :tag => :AR1, "rho" =>0.95))

--- a/test/ar1_cartesian.data
+++ b/test/ar1_cartesian.data
@@ -1,0 +1,9 @@
+grid: !Cartesian
+    a: [ 1-2*sig_z, k*0.9 ]
+    b: [ 1+2*sig_z, k*1.1 ]
+    orders: [10, 50]
+    mu: 3
+
+process: !AR1
+    rho: 0.95
+    sigma: 0.1

--- a/test/ar1_cartesian.expected
+++ b/test/ar1_cartesian.expected
@@ -1,0 +1,2 @@
+Dict("process" => Dict("sigma" => 0.1, :tag => :AR1, "rho" =>0.95),
+     "grid" => Dict("orders" => [10, 50], "b" => ["1+2*sig_z", "k*1.1"], "a" => ["1-2*sig_z", "k*0.9"], "mu" => 3, :tag => :Cartesian))

--- a/test/cartesian.data
+++ b/test/cartesian.data
@@ -1,0 +1,5 @@
+grid: !Cartesian
+    a: [ 1-2*sig_z, k*0.9 ]
+    b: [ 1+2*sig_z, k*1.1 ]
+    orders: [10, 50]
+    mu: 3

--- a/test/cartesian.expected
+++ b/test/cartesian.expected
@@ -1,0 +1,1 @@
+Dict("grid" => Dict("orders" => [10, 50], "b" => ["1+2*sig_z", "k*1.1"], "a" => ["1-2*sig_z", "k*0.9"], "mu" => 3, :tag => :Cartesian))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -107,4 +107,5 @@ more_constructors = let
                            for (t, s) in pairs])
 end
 
+runtests(tests)
 runtests(["cartesian", "ar1", "ar1_cartesian"], more_constructors)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -72,17 +72,39 @@ function equivalent(x, y)
     x == y
 end
 
-
 testdir = dirname(@__FILE__)
 
-for test in tests
-    data = YAML.load_file(joinpath(testdir, string(test, ".data")))
-    expected = evalfile(joinpath(testdir, string(test, ".expected")))
-    if !equivalent(data, expected)
-        @printf("%s: FAILED\n", test)
-        @printf("Expected:\n%s\nParsed:\n%s\n",
-                expected, data)
-    else
-        @printf("%s: PASSED\n", test)
+function runtests(tests, more_constructors=nothing)
+
+    for test in tests
+        data = YAML.load_file(
+            joinpath(testdir, string(test, ".data")),
+            more_constructors
+        )
+        expected = evalfile(joinpath(testdir, string(test, ".expected")))
+        if !equivalent(data, expected)
+            @printf("%s: FAILED\n", test)
+            @printf("Expected:\n%s\nParsed:\n%s\n",
+                    expected, data)
+        else
+            @printf("%s: PASSED\n", test)
+        end
     end
 end
+
+# test custom tags
+function construct_type_map(t::Symbol, constructor::YAML.Constructor,
+                            node::YAML.Node)
+    mapping = YAML.construct_mapping(constructor, node)
+    mapping[:tag] = t
+    mapping
+end
+
+more_constructors = let
+    pairs = [("!Cartesian", :Cartesian),
+             ("!AR1", :AR1)]
+    Dict{String,Function}([(t, (c, n) -> construct_type_map(s, c, n))
+                           for (t, s) in pairs])
+end
+
+runtests(["cartesian", "ar1", "ar1_cartesian"], more_constructors)


### PR DESCRIPTION
This code builds off of what @jdlangs did and adds support of importing YAML files with custom tags.

Right now the API is that `YAML.load` and `YAML.load_file` accepts a second, optional argument that is a `Dict{String,Function}` that maps tag names to functions used to handle the item with that tag. 

This isn't a perfect solution as my use of it outside YAML.jl requires calling `YAML.construct_mapping_node`, which isn't part of the public API.

I'd consider this a proof of concept.

cc @albop to review
