### PR TITLE
Remove old Compat items

### DIFF
--- a/src/YAML.jl
+++ b/src/YAML.jl
@@ -5,8 +5,16 @@ module YAML
 import Base: start, next, done, isempty, length, show
 import Codecs
 using Compat
-import Compat: AbstractString
-import Compat: Iterators
+using Compat.Dates
+using Compat.Printf
+
+if VERSION < v"0.7.0-DEV.2915"
+    isnumeric(c::Char) = isnumber(c)
+end
+
+if VERSION < v"0.7.0-DEV.3526"
+    Base.parse(T::Type{<:Integer}, s; base = base) = parse(T, s, base)
+end
 
 include("scanner.jl")
 include("parser.jl")

--- a/src/constructor.jl
+++ b/src/constructor.jl
@@ -1,6 +1,4 @@
 
-using Compat.Dates
-
 struct ConstructorError
     context::Union{AbstractString, Nothing}
     context_mark::Union{Mark, Nothing}

--- a/src/events.jl
+++ b/src/events.jl
@@ -1,5 +1,5 @@
 
-@compat abstract type Event end
+abstract type Event end
 
 struct StreamStartEvent <: Event
     start_mark::Mark

--- a/src/nodes.jl
+++ b/src/nodes.jl
@@ -1,5 +1,5 @@
 
-@compat abstract type Node end
+abstract type Node end
 
 mutable struct ScalarNode <: Node
     tag::AbstractString

--- a/src/scanner.jl
+++ b/src/scanner.jl
@@ -1,16 +1,6 @@
 
-using Compat.Printf
-
 include("queue.jl")
 include("buffered_input.jl")
-
-if VERSION < v"0.7.0-DEV.2915"
-    isnumeric(c::Char) = isnumber(c)
-end
-
-if VERSION < v"0.7.0-DEV.3526"
-    Base.parse(T::Type{<:Integer}, s; base = base) = parse(T, s, base)
-end
 
 # Position within the document being parsed
 struct Mark

--- a/src/tokens.jl
+++ b/src/tokens.jl
@@ -1,7 +1,7 @@
 
 # YAML Tokens.
 # Each token must include at minimum member "span::Span".
-@compat abstract type Token end
+abstract type Token end
 
 
 # The '%YAML' directive.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,7 +4,6 @@ module YAMLTests
 
 import YAML
 using Compat.Test
-using Compat.Dates
 
 const tests = [
     "spec-02-01",


### PR DESCRIPTION
Remove old Compat items that are no longer needed for 0.6+.  Also move newly added Compat items up to YAML.jl to keep them together and make it obvious what can be removed when Compat is no longer needed.